### PR TITLE
Working on mac but some issues loading map files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lo
 *.o
 *.obj
+/objects/*
 
 # Precompiled Headers
 *.gch
@@ -30,3 +31,10 @@
 *.exe
 *.out
 *.app
+
+# Mac
+.DS_Store
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes

--- a/bitmap.cpp
+++ b/bitmap.cpp
@@ -40,7 +40,7 @@ Bitmap_t bitmap_load_raw(const U8* bytes, U64 byte_count){
 
      bitmap.raw.bytes = (U8*)(malloc(byte_count));
      if(!bitmap.raw.bytes){
-          LOG("%s() failed: failed to allocate %lu bytes for bitmap\n", __FUNCTION__, byte_count);
+          LOG("%s() failed: failed to allocate %" PRIu64 " bytes for bitmap\n", __FUNCTION__, byte_count);
      }
      bitmap.raw.byte_count = byte_count;
 

--- a/demo.cpp
+++ b/demo.cpp
@@ -29,7 +29,7 @@ bool demo_begin(Demo_t* demo){
           fread(&demo->version, sizeof(demo->version), 1, demo->file);
           demo->entries = demo_entries_get(demo->file);
           demo->last_frame = demo->entries.entries[demo->entries.count - 1].frame;
-          LOG("playing demo %s: version %d with %ld actions across %ld frames\n", demo->filepath,
+          LOG("playing demo %s: version %d with %" PRId64 " actions across %" PRId64 " frames\n", demo->filepath,
               demo->version, demo->entries.count, demo->last_frame);
           break;
      }

--- a/main.cpp
+++ b/main.cpp
@@ -308,7 +308,7 @@ bool load_map_number_demo(Demo_t* demo, S16 map_number, S64* frame_count){
      demo->entries = demo_entries_get(demo->file);
      *frame_count = 0;
      demo->last_frame = demo->entries.entries[demo->entries.count - 1].frame;
-     LOG("testing demo %s: version %d with %ld actions across %ld frames\n", demo->filepath,
+     LOG("testing demo %s: version %d with %" PRId64 " actions across %" PRId64 " frames\n", demo->filepath,
          demo->version, demo->entries.count, demo->last_frame);
      return true;
 }
@@ -5563,7 +5563,7 @@ int main(int argc, char** argv){
                     draw_quad_wireframe(&pct_bar_outline_quad, 255.0f, 255.0f, 255.0f);
 
                     char buffer[64];
-                    snprintf(buffer, 64, "F: %ld/%ld C: %d", frame_count, play_demo.last_frame, collision_attempts);
+                    snprintf(buffer, 64, "F: %" PRId64 "/%" PRId64 " C: %d", frame_count, play_demo.last_frame, collision_attempts);
 
                     glBindTexture(GL_TEXTURE_2D, text_texture);
                     glBegin(GL_QUADS);

--- a/makefile
+++ b/makefile
@@ -1,0 +1,40 @@
+CC      := clang++
+FLAGS 	:= -Wall -Werror -Wshadow -Wextra -std=c++11 -ggdb3 -DDEBUG 
+LINK  	:= -lSDL2 -pthread
+OBJ_DIR := ./objects
+EXE   	:= game
+SRC     := $(wildcard *.cpp) \
+
+OBJECTS := $(SRC:%.cpp=$(OBJ_DIR)/%.o)
+
+# Tested and working on mac, untested on windows and linux
+ifeq ($(OS),Windows_NT)
+	LINK += -lGL
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		LINK += -lGL
+
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		LINK += -framework OpenGL
+
+	endif
+endif
+
+all: $(EXE)
+
+$(EXE): $(OBJECTS)
+	$(CC) -o $(EXE) $^ $(LINK)
+
+$(OBJ_DIR)/%.o: %.cpp
+	@mkdir -p $(@D)
+	$(CC) $(FLAGS) -c $< -o $@
+
+.PHONY: all clean release
+
+release: FLAGS += -O3
+release: all
+
+clean:
+	-@rm -rvf $(EXE) $(OBJ_DIR)/*

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CC      := clang++
-FLAGS 	:= -Wall -Werror -Wshadow -Wextra -std=c++11 -ggdb3 -DDEBUG 
+FLAGS 	:= -Wall -Werror -Wshadow -Wextra -std=c++11
 LINK  	:= -lSDL2 -pthread
 OBJ_DIR := ./objects
 EXE   	:= game
@@ -22,6 +22,9 @@ else
 	endif
 endif
 
+debug: FLAGS += -ggdb3 -DDEBUG
+debug: all
+
 all: $(EXE)
 
 $(EXE): $(OBJECTS)
@@ -31,10 +34,10 @@ $(OBJ_DIR)/%.o: %.cpp
 	@mkdir -p $(@D)
 	$(CC) $(FLAGS) -c $< -o $@
 
-.PHONY: all clean release
+.PHONY: all clean release debug
 
 release: FLAGS += -O3
 release: all
 
 clean:
-	-@rm -rvf $(EXE) $(OBJ_DIR)/*
+	-@rm -rf $(EXE) $(OBJ_DIR)/*

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ FLAGS 	:= -Wall -Werror -Wshadow -Wextra -std=c++11
 LINK  	:= -lSDL2 -pthread
 OBJ_DIR := ./objects
 EXE   	:= game
-SRC     := $(wildcard *.cpp) \
+SRC     := $(wildcard *.cpp)
 
 OBJECTS := $(SRC:%.cpp=$(OBJ_DIR)/%.o)
 
@@ -14,15 +14,15 @@ else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
 		LINK += -lGL
-
+		DBFLAGS = -ggdb3 -DDEBUG
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		LINK += -framework OpenGL
-
+		DBFLAGS = -g
 	endif
 endif
 
-debug: FLAGS += -ggdb3 -DDEBUG
+debug: FLAGS += $(DBFLAGS)
 debug: all
 
 all: $(EXE)
@@ -40,4 +40,4 @@ release: FLAGS += -O3
 release: all
 
 clean:
-	-@rm -rf $(EXE) $(OBJ_DIR)/*
+	-@rm -rf $(EXE) $(OBJ_DIR)

--- a/raw.cpp
+++ b/raw.cpp
@@ -28,7 +28,7 @@ Raw_t raw_load_file(const char* filename)
 
      size_t items_read = fread(raw.bytes, (size_t)(raw.byte_count), 1, file);
      if(items_read != 1){
-          fprintf(stderr, "%s() failed to read %lu bytes from %s\n", __FUNCTION__, raw.byte_count, filename);
+          fprintf(stderr, "%s() failed to read %" PRIu64 " bytes from %s\n", __FUNCTION__, raw.byte_count, filename);
           memset(&raw, 0, sizeof(raw));
           fclose(file);
           return raw;

--- a/types.h
+++ b/types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define __STDC_FORMAT_MACROS
+#include <cinttypes>
 #include <cstdint>
 
 typedef int8_t  S8;

--- a/ui.h
+++ b/ui.h
@@ -4,7 +4,12 @@
 #include "vec.h"
 #include "tags.h"
 
-#include <GL/gl.h>
+#ifdef __linux
+    #include <GL/gl.h>
+#elif __APPLE__
+    #define GL_SILENCE_DEPRECATION
+    #include <OpenGL/gl.h>
+#endif
 
 #define CHECKBOX_DIMENSION (8.0 * PIXEL_SIZE)
 #define THUMBNAIL_UI_DIMENSION (0.1375f)

--- a/world.cpp
+++ b/world.cpp
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdlib.h>
+#include <errno.h>
 
 static int ascending_block_height_comparer(const void* a, const void* b){
     Block_t* real_a = *(Block_t**)(a);
@@ -43,10 +44,8 @@ LogMapNumberResult_t load_map_number(S32 map_number, Coord_t* player_start, Worl
      // search through directory to find file starting with 3 digit map number
      DIR* d = opendir("content");
      if(!d){
-         printf("load_map_number: opendir() failed\n");
+         LOG("load_map_number(): opendir() failed: %s\n", strerror(errno));
          return result;
-     }else{
-         printf("load_map_number: opendir() success\n");
      }
      struct dirent* dir;
      char filepath[512] = {};

--- a/world.cpp
+++ b/world.cpp
@@ -42,7 +42,12 @@ LogMapNumberResult_t load_map_number(S32 map_number, Coord_t* player_start, Worl
 
      // search through directory to find file starting with 3 digit map number
      DIR* d = opendir("content");
-     if(!d) return result;
+     if(!d){
+         printf("load_map_number: opendir() failed\n");
+         return result;
+     }else{
+         printf("load_map_number: opendir() success\n");
+     }
      struct dirent* dir;
      char filepath[512] = {};
      char match[4] = {};


### PR DESCRIPTION
Tweaks include changing format specifiers to C99 platform-independent versions, adding defines to handle platform-specific header file includes.

If starting with '-map', the map is successfully loaded, however pressing [ or ] fails at opendir() in load_map_number(). If started without '-map' it fails to load all files. See attached log.
[bryte.log](https://github.com/justy989/game/files/4530790/bryte.log)
